### PR TITLE
[33] Actions not enabled in Package Explorer view

### DIFF
--- a/dev/org.eclipse.codewind.openapi.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.openapi.ui/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.core.expressions,
- org.eclipse.codewind.openapi.core
+ org.eclipse.codewind.openapi.core,
+ org.eclipse.jdt.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.codewind.openapi.ui
 Bundle-ActivationPolicy: lazy

--- a/dev/org.eclipse.codewind.openapi.ui/plugin.xml
+++ b/dev/org.eclipse.codewind.openapi.ui/plugin.xml
@@ -203,15 +203,47 @@
                   commandId="org.eclipse.codewind.openapi.ui.commands.clientCommand"
                   tooltip="%CREATE_CLIENT_DESCRIPTION">
             	<visibleWhen>
-           			<with variable="selection">
+           			<with variable="activeMenuSelection">
            			  <count value="1"/>
               		  <iterate>
-              		     <adapt type="org.eclipse.core.resources.IProject">
+              		     <adapt type="org.eclipse.core.resources.IResource">
 		    				<test forcePluginActivation="true" property="org.eclipse.codewind.openapi.ui.validSelection" value="true"/>    
 			            </adapt>
               	 	  </iterate>
            			</with>
             	</visibleWhen>
+            </command>
+            <command
+                  id="org.eclipse.codewind.openapi.ui.packageExplorer.serverCommand"
+                  commandId="org.eclipse.codewind.openapi.ui.commands.serverCommand"
+                  tooltip="%CREATE_SERVER_DESCRIPTION">
+            <visibleWhen>
+               <with
+                     variable="activeMenuSelection">
+                  <count value="1"/>
+              		  <iterate>
+              		     <adapt type="org.eclipse.core.resources.IResource">
+		    				<test forcePluginActivation="true" property="org.eclipse.codewind.openapi.ui.validSelection" value="true"/>    
+			            </adapt>
+              	 	  </iterate>
+               </with>
+            </visibleWhen>
+            </command>
+            <command
+                  id="org.eclipse.codewind.openapi.ui.packageExplorer.htmlCommand"
+                  commandId="org.eclipse.codewind.openapi.ui.commands.htmlCommand"
+                  tooltip="%CREATE_HTML_DESCRIPTION">
+            <visibleWhen>
+               <with
+                  variable="activeMenuSelection">
+                  <count value="1"/>
+              		  <iterate>
+              		     <adapt type="org.eclipse.core.resources.IResource">
+		    				<test forcePluginActivation="true" property="org.eclipse.codewind.openapi.ui.validSelection" value="true"/>    
+			            </adapt>
+              	 	  </iterate>
+               </with>
+            </visibleWhen>
             </command>
          </menu>
       </menuContribution>  

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Activator.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Activator.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.eclipse.codewind.openapi.ui;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 import org.eclipse.codewind.openapi.ui.util.UILogger;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -71,6 +74,15 @@ public class Activator extends AbstractUIPlugin {
 	
 	public static void log(int severity, String message) {
 		plugin.getLog().log(new Status(severity, PLUGIN_ID, message));
+	}
+	
+	public static void log(int severity, Exception e) {
+		if (UILogger.ERROR) {
+			StringWriter writer = new StringWriter();
+			PrintWriter pw = new PrintWriter(writer);
+			e.printStackTrace(pw);
+			plugin.getLog().log(new Status(severity, PLUGIN_ID, writer.toString()));				
+		}
 	}
 
 }

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizardPage.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizardPage.java
@@ -19,6 +19,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -153,7 +154,7 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 		label = new Label(container, SWT.NULL);
 		label.setText(Messages.WIZARD_PAGE_LANGUAGE);
 
-		languages = new Combo(container, SWT.SIMPLE | SWT.READ_ONLY);
+		languages = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
 		gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.horizontalSpan = 2;
 		languages.setLayoutData(gd);
@@ -163,7 +164,7 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 		label.setText(Messages.WIZARD_PAGE_GENERATOR_TYPE);
 		label.setToolTipText(Messages.WIZARD_PAGE_GENERATOR_TYPE_TOOLTIP);
 
-		generatorTypes = new Combo(container, SWT.SIMPLE| SWT.READ_ONLY);
+		generatorTypes = new Combo(container, SWT.DROP_DOWN | SWT.READ_ONLY);
 		gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.horizontalSpan = 2;
 		generatorTypes.setToolTipText(Messages.WIZARD_PAGE_GENERATOR_TYPE_TOOLTIP);
@@ -193,6 +194,9 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 			} else if (obj instanceof IContainer) {
 				IContainer container = (IContainer) obj;
 				project = container.getProject();
+			} else if (obj instanceof IJavaProject) {
+				IJavaProject javaProj = (IJavaProject)obj;
+				project = javaProj.getProject();
 			} else {
 				String possibleLanguage = Util.getProjectLanguage(obj);
 				if (possibleLanguage.length() > 0) {
@@ -201,13 +205,7 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 				project = Util.getProject(obj);
 			}
 			if (project != null) {
-				boolean foundInitialSpec = findSpecificationAtRoot("openapi.yaml"); //$NON-NLS-1$
-				if (!foundInitialSpec) {
-					foundInitialSpec = findSpecificationAtRoot("openapi.yml"); //$NON-NLS-1$
-					if (!foundInitialSpec) {
-						foundInitialSpec = findSpecificationAtRoot("openapi.json"); //$NON-NLS-1$
-					}
-				}
+				initWithDefinitionAtRoot(); //$NON-NLS-1$
 				projectText.setText(project.getName());
 			}
 		}		
@@ -333,7 +331,14 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 				if (resource instanceof IFile) {
 					IFile f = (IFile) resource;
 					String fileName = f.getName();
-					if (fileName.toLowerCase().contains("openapi") && (fileName.endsWith(".yaml") || fileName.endsWith(".yml") || fileName.endsWith(".json"))) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+					if ((fileName.endsWith(".yaml") || fileName.endsWith(".yml") || fileName.endsWith(".json")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						&& !fileName.startsWith(".")
+						&& !fileName.toLowerCase().equals("package.json")
+						&& !fileName.toLowerCase().equals("package-lock.json")
+						&& !fileName.toLowerCase().equals("chart.yaml")
+						&& !fileName.toLowerCase().equals("nodemon.json")
+						&& !fileName.toLowerCase().equals("manifest.yml")
+						&& !fileName.toLowerCase().equals("devfile.yaml")) {
 						return true;
 					}
 				} else {
@@ -346,7 +351,8 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 		if (ed.open() == ElementTreeSelectionDialog.OK) {
 			Object[] result = ed.getResult();
 			if (result.length == 1) {
-				fileText.setText(((IFile)result[0]).getFullPath().toString());
+				preselectedOpenApiFile = (IFile)result[0];
+				fileText.setText(preselectedOpenApiFile.getFullPath().toString());
 			}
 		}
 	}
@@ -383,10 +389,20 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 		}
 	}
 	
-	protected boolean findSpecificationAtRoot(String fileName) {
-		IResource spec1 = project.findMember(fileName);
-		if (spec1 != null && spec1.exists() && spec1 instanceof IFile && spec1.isAccessible()) {
-			preselectedOpenApiFile = (IFile)spec1;
+	protected void initWithDefinitionAtRoot() {
+		boolean isFound = checkForDefinition("openapi.yaml");
+		if (!isFound) {
+			isFound = checkForDefinition("openapi.yml");
+			if (!isFound) {
+				isFound = checkForDefinition("openapi.json");
+			}
+		}
+	}
+	
+	protected boolean checkForDefinition(String fileName) {
+		IResource res = project.findMember(fileName);
+		if (res != null && res.exists() && res instanceof IFile && res.isAccessible()) {
+			preselectedOpenApiFile = (IFile)res;
 			fileText.setText(preselectedOpenApiFile.getFullPath().toString());
 			return true;
 		}

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/GenerateHtmlWizard.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/GenerateHtmlWizard.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.codewind.openapi.ui.wizard;
 
-import org.eclipse.codewind.openapi.core.Activator;
+import org.eclipse.codewind.openapi.ui.Activator;
 import org.eclipse.codewind.openapi.ui.Constants;
 import org.eclipse.codewind.openapi.ui.commands.AbstractOpenApiGeneratorCommand;
 import org.eclipse.codewind.openapi.ui.commands.GenerateHtmlCommand;

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/GenerateHtmlWizardPage.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/GenerateHtmlWizardPage.java
@@ -122,13 +122,7 @@ public class GenerateHtmlWizardPage extends AbstractGenerateWizardPage {
 				project = Util.getProject(obj);
 			}
 			if (project != null) {
-				boolean foundInitialSpecification = findSpecificationAtRoot("openapi.yaml"); //$NON-NLS-1$
-				if (!foundInitialSpecification) {
-					foundInitialSpecification = findSpecificationAtRoot("openapi.yml"); //$NON-NLS-1$
-					if (!foundInitialSpecification) {
-						foundInitialSpecification = findSpecificationAtRoot("openapi.json"); //$NON-NLS-1$
-					}
-				}
+				initWithDefinitionAtRoot();
 				projectText.setText(project.getName());
 				outputFolder.setText(project.getFullPath().toString());
 			}


### PR DESCRIPTION
PR for https://github.com/eclipse/codewind-openapi-eclipse/issues/33

This PR add the remaining actions to the Package Explorer view (Previously, the actions were working only in the Project Explorer View).  Currently, the menu only shows the client action but not the others.

Also, there was a fix that was made in the VS Code extension that should have been brought over to the Eclipse plugin.  (See https://github.com/eclipse/codewind-openapi-vscode/pull/21)
This minor change is also included.

Also there are some miscellaneous fixes that are included, including a scenario where the selected document file was not passed to the gen command, so nothing was generated.

These are all must fixes

Signed-off-by: Keith Chong <kchong@ca.ibm.com>