### PR TITLE
Update eclipse version, since the old version no longer exists.

### DIFF
--- a/dev/gradle.properties
+++ b/dev/gradle.properties
@@ -11,8 +11,8 @@
 
 org.gradle.daemon=false
 
-eclipse.sdk.url=http://mirrors.xmission.com/eclipse/eclipse/downloads/drops4/R-4.11-201903070500/eclipse-SDK-4.11-linux-gtk-x86_64.tar.gz
-eclipse.target.platform.url=http://mirrors.xmission.com/eclipse/technology/epp/downloads/release/2019-03/R/eclipse-jee-2019-03-R-linux-gtk-x86_64.tar.gz
+eclipse.sdk.url=http://mirrors.xmission.com/eclipse/eclipse/downloads/drops4/R-4.14-201912100610/eclipse-SDK-4.14-linux-gtk-x86_64.tar.gz
+eclipse.target.platform.url=http://mirrors.xmission.com/eclipse/technology/epp/downloads/release/2019-12/R/eclipse-jee-2019-12-R-linux-gtk-x86_64.tar.gz
 
 eclipse.sdk.archive.location=/ant_build/eclipse_sdk.tar.gz
 eclipse.sdk.folder=/ant_build/eclipse_sdk/


### PR DESCRIPTION
This version no longer exists:

http://mirrors.xmission.com/eclipse/technology/epp/downloads/release/2019-03/R/eclipse-jee-2019-03-R-linux-gtk-x86_64.tar.gz


Signed-off-by: tiaoyuw <tiaoyuw@ca.ibm.com>