### PR TITLE
Fix build failure caused by newly introduced test zip

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,8 @@ pipeline {
                         export BUILD_INFO="build_info.properties"
                         export sshHost="genie.codewind@projects-storage.eclipse.org"
                         export deployDir="/home/data/httpd/download.eclipse.org/codewind/$REPO_NAME"
+
+                        rm $OUTPUT_DIR/$REPO_NAME-test-*.zip
                     
                         if [ -z $CHANGE_ID ]; then
                             UPLOAD_DIR="$GIT_BRANCH/$BUILD_ID"


### PR DESCRIPTION
No need to deploy the test*.zip. Remove before deploying the update site zip. 