### PR TITLE
Update repo for openapi-generator-cli-4.2.2.jar

### DIFF
--- a/dev/buildAll.gradle
+++ b/dev/buildAll.gradle
@@ -109,7 +109,7 @@ task downloadJson(type: Download) {
 
 task downloadOpenApiCli(type: Download) {
     println("Downloading OpenAPI Cli jar")
-    sourceUrl = 'http://central.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.2/openapi-generator-cli-4.2.2.jar'
+    sourceUrl = 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.2/openapi-generator-cli-4.2.2.jar'
     target = openApiCliFile
 }
 


### PR DESCRIPTION
The URL for openapi-generator-cli-4.2.2.jar has changed. I updated the URL and ran gradlew to verify that it built properly