### PR TITLE
Cleanup docker-build agent workspace after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,4 +132,10 @@ pipeline {
             }
         }       
     } 
+    post {
+        always {
+            echo 'Clean up workspace'
+            deleteDir() /* clean up our workspace */
+        }
+    }
 }


### PR DESCRIPTION
In order to prevent 'no space' issue on the docker-build agent, clean up the workspace after a build. 