### PR TITLE
Fix jar signing issue for open api eclipse

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,9 @@ pipeline {
                     dir('dev') { 
                         sh './gradlew --stacktrace' 
                         stash name: 'codewind-openapi-eclipse-test.zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
-                        rm 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
+                        delete fileTree('ant_build/artifacts') { 
+                            include 'codewind-openapi-eclipse-test-*.zip' 
+                        }
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 script {
                     try {
-                        dir('dev/ant_build/artifacts') { 
+                        dir('$WORKSPACE/dev/ant_build/artifacts') { 
                             unstash 'codewind-openapi-eclipse-test.zip'
                             unstash 'codewind-openapi-eclipse-zip'
                         }
@@ -58,6 +58,8 @@ pipeline {
                     } finally {
                         junit 'dev/junit-results.xml'
                     }
+                    dir('dev') { 	
+                        stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,11 @@ pipeline {
                 label "docker-build"
             }
 
+            when {
+                beforeAgent true
+                changeRequest()
+            }
+            
             steps {
                 script {
                     try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,10 +24,11 @@ pipeline {
                         which java    
                     '''
                     
-                    dir('dev/ant_build/artifacts') { 
+                    dir('dev') { 
                         sh './gradlew --stacktrace' 
+                        cd 'ant_build/artifacts'
                         stash name: 'codewind-openapi-eclipse-test.zip', includes: 'codewind-openapi-eclipse-test-*.zip'
-                        sh 'rm ./codewind-openapi-eclipse-test-*.zip' 
+                        sh 'rm codewind-openapi-eclipse-test-*.zip' 
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'codewind-openapi-eclipse-*.zip'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
                     }
                     dir('dev') { 	
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
+                    }
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,17 +42,19 @@ pipeline {
             steps {
                 script {
                     try {
-                        dir('dev/ant_build/artifacts') { 
+                        dir('/development/ant_build/artifacts') { 
                             unstash 'codewind-openapi-eclipse-test.zip'
+                            unstash 'codewind-openapi-eclipse-zip'
                         }
 
                         sh '''#!/usr/bin/env bash
                             docker build --no-cache -t test-image ./dev
                             export CWD=$(pwd)
                             echo "Current directory is ${CWD}"
+                            ///home/root/workspace/_codewind-openapi-eclipse_testSJ
                             docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
 
-                            rm $WORKSPACE/dev/ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
+                            rm /development/ant_build/artifacts/codewind-openapi-eclipse-*.zip
                         '''
                     } finally {
                         junit 'dev/junit-results.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,14 +54,9 @@ pipeline {
                             export CWD=$(pwd)
                             echo "Current directory is ${CWD}"
                             docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
-
-                            rm $WORKSPACE/dev/ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
                         '''
                     } finally {
                         junit 'dev/junit-results.xml'
-                    }
-                    dir('dev/ant_build/artifacts') { 	
-                        stash name: 'codewind-openapi-eclipse-zip', includes: 'codewind-openapi-eclipse-*.zip'
                     }
                 }
             }
@@ -76,6 +71,7 @@ pipeline {
                         docker system df
                         df -lh
                     '''
+                    deleteDir()
                 }
             }      
         }  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,11 +24,11 @@ pipeline {
                         which java    
                     '''
                     
-                    dir('dev') { 
+                    dir('dev/ant_build/artifacts') { 
                         sh './gradlew --stacktrace' 
-                        stash name: 'codewind-openapi-eclipse-test.zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
-                        sh 'rm ./ant_build/artifacts/codewind-openapi-eclipse-test-*.zip' 
-                        stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
+                        stash name: 'codewind-openapi-eclipse-test.zip', includes: 'codewind-openapi-eclipse-test-*.zip'
+                        sh 'rm ./codewind-openapi-eclipse-test-*.zip' 
+                        stash name: 'codewind-openapi-eclipse-zip', includes: 'codewind-openapi-eclipse-*.zip'
                     }
                 }
             }
@@ -38,16 +38,11 @@ pipeline {
             agent {
                 label "docker-build"
             }
-
-            when {
-                beforeAgent true
-                changeRequest()
-            }
-            
+        
             steps {
                 script {
                     try {
-                        dir('$WORKSPACE/dev/ant_build/artifacts') { 
+                        dir('dev/ant_build/artifacts') { 
                             unstash 'codewind-openapi-eclipse-test.zip'
                             unstash 'codewind-openapi-eclipse-zip'
                         }
@@ -63,8 +58,8 @@ pipeline {
                     } finally {
                         junit 'dev/junit-results.xml'
                     }
-                    dir('dev') { 	
-                        stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
+                    dir('dev/ant_build/artifacts') { 	
+                        stash name: 'codewind-openapi-eclipse-zip', includes: 'codewind-openapi-eclipse-*.zip'
                     }
                 }
             }
@@ -100,7 +95,7 @@ pipeline {
                 sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
                     println("Deploying codewind-openapi-eclipse to downoad area...")
                     
-                    dir("$WORKSPACE/dev") {
+                    dir("$WORKSPACE/dev/ant_build/artifacts") {
                         unstash 'codewind-openapi-eclipse-zip'
                     }
                     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,8 @@ pipeline {
                     
                     dir('dev') { 
                         sh './gradlew --stacktrace' 
-                        cd 'ant_build/artifacts'
+                    }
+                    dir('dev/ant_build/artifacts') { 
                         stash name: 'codewind-openapi-eclipse-test.zip', includes: 'codewind-openapi-eclipse-test-*.zip'
                         sh 'rm codewind-openapi-eclipse-test-*.zip' 
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'codewind-openapi-eclipse-*.zip'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 script {
                     try {
-                        dir('$WORKSPACE/dev/ant_build/artifacts') { 
+                        dir('dev/ant_build/artifacts') { 
                             unstash 'codewind-openapi-eclipse-test.zip'
                             unstash 'codewind-openapi-eclipse-zip'
                         }
@@ -92,14 +92,14 @@ pipeline {
                 sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
                     println("Deploying codewind-openapi-eclipse to downoad area...")
                     
-                    dir("dev") {
+                    dir("$WORKSPACE/dev") {
                         unstash 'codewind-openapi-eclipse-zip'
                     }
                     
                     sh '''
                         export REPO_NAME="codewind-openapi-eclipse"
                         export OUTPUT_NAME="codewind-openapi-eclipse"
-                        export OUTPUT_DIR="dev/ant_build/artifacts"
+                        export OUTPUT_DIR="$WORKSPACE/dev/ant_build/artifacts"
                         export DOWNLOAD_AREA_URL="https://download.eclipse.org/codewind/$REPO_NAME"
                         export LATEST_DIR="latest"
                         export BUILD_INFO="build_info.properties"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             steps {
                 script {
                     try {
-                        dir('/development/ant_build/artifacts') { 
+                        dir('$WORKSPACE/dev/ant_build/artifacts') { 
                             unstash 'codewind-openapi-eclipse-test.zip'
                             unstash 'codewind-openapi-eclipse-zip'
                         }
@@ -51,10 +51,9 @@ pipeline {
                             docker build --no-cache -t test-image ./dev
                             export CWD=$(pwd)
                             echo "Current directory is ${CWD}"
-                            ///home/root/workspace/_codewind-openapi-eclipse_testSJ
                             docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
 
-                            rm /development/ant_build/artifacts/codewind-openapi-eclipse-*.zip
+                            rm $WORKSPACE/dev/ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
                         '''
                     } finally {
                         junit 'dev/junit-results.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,8 @@
 #!groovy​
 
 pipeline {
-    agent {
-        label "docker-build"
-    }
+
+    agent any
 
     options {
         timestamps() 
@@ -33,6 +32,10 @@ pipeline {
         } 
 
         stage('Test') {
+            agent {
+                label "docker-build"
+            }
+
             steps {
                 script {
                   try {
@@ -79,9 +82,7 @@ pipeline {
             options {
                 skipDefaultCheckout()
             }
-
-            agent any
-
+            
             steps {
                 sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
                     println("Deploying codewind-openapi-eclipse to downoad area...")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,7 @@ pipeline {
                     dir('dev') { 
                         sh './gradlew --stacktrace' 
                         stash name: 'codewind-openapi-eclipse-test.zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
-                        delete fileTree('ant_build/artifacts') { 
-                            include 'codewind-openapi-eclipse-test-*.zip' 
-                        }
+                        sh 'rm ./ant_build/artifacts/codewind-openapi-eclipse-test-*.zip' 
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                     dir('dev') { 
                         sh './gradlew --stacktrace' 
                         stash name: 'codewind-openapi-eclipse-test.zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
-                        rm ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
+                        rm 'ant_build/artifacts/codewind-openapi-eclipse-test-*.zip'
                         stash name: 'codewind-openapi-eclipse-zip', includes: 'ant_build/artifacts/codewind-openapi-eclipse-*.zip'
                     }
                 }
@@ -41,19 +41,19 @@ pipeline {
 
             steps {
                 script {
-                  try {
-                    dir('dev/ant_build/artifacts') { 
-                        unstash 'codewind-openapi-eclipse-test.zip'
-                    }
+                    try {
+                        dir('dev/ant_build/artifacts') { 
+                            unstash 'codewind-openapi-eclipse-test.zip'
+                        }
 
-                    sh '''#!/usr/bin/env bash
-                        docker build --no-cache -t test-image ./dev
-                        export CWD=$(pwd)
-                        echo "Current directory is ${CWD}"
-                        docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
+                        sh '''#!/usr/bin/env bash
+                            docker build --no-cache -t test-image ./dev
+                            export CWD=$(pwd)
+                            echo "Current directory is ${CWD}"
+                            docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
 
-                        rm $WORKSPACE/dev/ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
-                    '''
+                            rm $WORKSPACE/dev/ant_build/artifacts/codewind-openapi-eclipse-test-*.zip
+                        '''
                     } finally {
                         junit 'dev/junit-results.xml'
                     }


### PR DESCRIPTION
fixes https://github.com/eclipse/codewind/issues/1890

The signing jar issue was caused by calling it from a docker-build agent which is not supported by Eclipse Jenkins for now. The fix would be running only 'test' stage on a docker-build agent and run signjar on non-docker-build agent. 
