### PR TITLE
[0.9.0] OpenAPI: Make use of Open Liberty Library

### DIFF
--- a/dev/org.eclipse.codewind.openapi.base.feature/feature.xml
+++ b/dev/org.eclipse.codewind.openapi.base.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.codewind.openapi.base.feature"
       label="%featureName"
-      version="1.0.400.qualifier"
+      version="1.0.500.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/dev/org.eclipse.codewind.openapi.feature/feature.xml
+++ b/dev/org.eclipse.codewind.openapi.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.codewind.openapi.feature"
       label="%featureName"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/dev/org.eclipse.codewind.openapi.ui/META-INF/MANIFEST.MF
+++ b/dev/org.eclipse.codewind.openapi.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Codewind OpenAPI Tools UI
 Bundle-SymbolicName: org.eclipse.codewind.openapi.ui;singleton:=true
-Bundle-Version: 1.0.400.qualifier
+Bundle-Version: 1.0.500.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.eclipse.codewind.openapi.ui.Activator
 Bundle-Vendor: IBM

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/commands/AbstractOpenApiGeneratorCommand.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/commands/AbstractOpenApiGeneratorCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -51,6 +51,7 @@ public abstract class AbstractOpenApiGeneratorCommand extends WorkspaceModifyOpe
 	protected String language = null;
 	protected String generatorType = null;
 	protected boolean pomFileExists = false;
+	protected String codewindProjectTypeId = null;
 	
 	public AbstractOpenApiGeneratorCommand() {
 		// empty
@@ -78,6 +79,10 @@ public abstract class AbstractOpenApiGeneratorCommand extends WorkspaceModifyOpe
 	
 	public void setGeneratorType(String generatorType) {
 		this.generatorType = generatorType;
+	}
+	
+	public void setCodewindProjectTypeId(String codewindProjectTypeId) {
+		this.codewindProjectTypeId = codewindProjectTypeId;
 	}
 	
 	public void setOutputFolderString(String outputFolderString) {

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/commands/GenerateServerCommand.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/commands/GenerateServerCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -18,6 +18,7 @@ import java.util.List;
 
 import org.eclipse.codewind.openapi.core.commands.CommandRunner;
 import org.eclipse.codewind.openapi.ui.Activator;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
@@ -44,6 +45,29 @@ public class GenerateServerCommand extends AbstractOpenApiGeneratorCommand {
 		mainArgsList.add("generate"); //$NON-NLS-1$
 		mainArgsList.add("-g"); //$NON-NLS-1$
 		mainArgsList.add(generatorType);
+		
+		boolean isLiberty = false;
+		boolean isAppsodyLiberty = false;
+        
+		IResource serverProjectFile = project.findMember("/src/main/liberty/config/server.xml"); //$NON-NLS-1$
+		if (serverProjectFile != null) {
+			isLiberty = serverProjectFile.exists();
+			
+			IResource appsodyProjectFile = project.findMember(".appsody-config.yaml"); //$NON-NLS-1$
+			
+			if (appsodyProjectFile != null) {
+				isAppsodyLiberty = isLiberty && appsodyProjectFile.exists();
+			}	
+		}
+		
+		if (generatorType.equals("jaxrs-spec") && (codewindProjectTypeId != null && codewindProjectTypeId.toLowerCase().indexOf("liberty") >= 0) //$NON-NLS-1$ //$NON-NLS-2$ 
+				|| (codewindProjectTypeId != null && codewindProjectTypeId.toLowerCase().indexOf("docker") >= 0 && isLiberty) //$NON-NLS-1$ 
+				|| (codewindProjectTypeId != null && codewindProjectTypeId.toLowerCase().indexOf("appsodyextension") >= 0 && isAppsodyLiberty)) { //$NON-NLS-1$
+			mainArgsList.add("--library"); //$NON-NLS-1$
+			mainArgsList.add("openliberty"); //$NON-NLS-1$
+			mainArgsList.add("--enable-post-process-file"); //$NON-NLS-1$
+		}
+		
 		mainArgsList.add("-i"); //$NON-NLS-1$
 		if (this.openApiFile != null) {
 			mainArgsList.add(argSurround + openApiFile.getLocation().toOSString() + argSurround);

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizard.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizard.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -90,6 +90,8 @@ public abstract class AbstractGenerateWizard extends Wizard implements INewWizar
 		}
 
 		PROJECT_TYPE projectType = page.getProjectType();
+		
+		cmd.setCodewindProjectTypeId(page.getCodewindProjectTypeId());
 
 		// Need a wrapper outside the context of the wizard page, since the wizard will be disposed of.
 		// Pass in the needed parameters gathered by the wizard

--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizardPage.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/wizard/AbstractGenerateWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2020 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -126,6 +126,10 @@ public abstract class AbstractGenerateWizardPage extends WizardPage {
 		return tempOrigFileName;
 	}
 
+	public String getCodewindProjectTypeId() {
+		return codewindProjectTypeId;
+	}
+	
 	@Override
 	public void createControl(Composite parent) {
 		Composite container = new Composite(parent, SWT.NULL);


### PR DESCRIPTION
Porting to 0.9.0. In the the other PR (https://github.com/eclipse/codewind-openapi-eclipse/pull/130/files) I forgot to update dev/org.eclipse.codewind.openapi.base.feature/feature.xml, I will port that back to master.