### PR TITLE
Fix build failure on clean up workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,6 @@ pipeline {
                         docker system df
                         df -lh
                     '''
-                    deleteDir()
                 }
             }      
         }  
@@ -139,4 +138,10 @@ pipeline {
             }
         }       
     } 
+    post {
+        always {
+            echo 'Clean up workspace'
+            deleteDir() /* clean up our workspace */
+        }
+    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,10 +139,4 @@ pipeline {
             }
         }       
     } 
-    post {
-        always {
-            echo 'Clean up workspace'
-            deleteDir() /* clean up our workspace */
-        }
-    }
 }

--- a/dev/ant_build/build-cw.xml
+++ b/dev/ant_build/build-cw.xml
@@ -10,7 +10,7 @@
 -->
 
 <project name="cw_build" default="generateOpenCWUpdateSite">
-    <property name="level_tag" value="0.8.0"/>
+    <property name="level_tag" value="0.10.0"/>
     <property name="delegate.build.dir" location="${basedir}/../" />
     <property name="disable.run.executeMetatypeValidation" value="true"/>
     <property name="disable.run.unzipIfixReleaseZip" value="true"/>

--- a/dev/org.eclipse.codewind.openapi.feature.test/category.xml
+++ b/dev/org.eclipse.codewind.openapi.feature.test/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.codewind.openapi.feature.test_0.8.0.qualifier.jar" id="org.eclipse.codewind.openapi.feature.test" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.codewind.openapi.feature.test_0.10.0.qualifier.jar" id="org.eclipse.codewind.openapi.feature.test" version="0.10.0.qualifier">
       <category name="org.eclipse.codewind.openapi.category.test"/>
    </feature>
    <category-def name="org.eclipse.codewind.openapi.category.test" label="OpenAPI Tools Test"/>

--- a/dev/org.eclipse.codewind.openapi.feature.test/feature.xml
+++ b/dev/org.eclipse.codewind.openapi.feature.test/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.codewind.openapi.feature.test"
       label="%featureName"
-      version="0.8.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/dev/org.eclipse.codewind.openapi.feature/category.xml
+++ b/dev/org.eclipse.codewind.openapi.feature/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.codewind.openapi.feature_0.8.0.qualifier.jar" id="org.eclipse.codewind.openapi.feature" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.codewind.openapi.feature_0.10.0.qualifier.jar" id="org.eclipse.codewind.openapi.feature" version="0.10.0.qualifier">
       <category name="org.eclipse.codewind.openapi.category"/>
    </feature>
    <category-def name="org.eclipse.codewind.openapi.category" label="OpenAPI Tools"/>

--- a/dev/org.eclipse.codewind.openapi.feature/feature.xml
+++ b/dev/org.eclipse.codewind.openapi.feature/feature.xml
@@ -14,7 +14,7 @@
 <feature
       id="org.eclipse.codewind.openapi.feature"
       label="%featureName"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="%providerName">
 
    <description>


### PR DESCRIPTION
fixes https://github.com/eclipse/codewind/issues/2415

The Jenkins build failure is caused by the recent change - build using non-root user. 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=559302

Remove unnecessary 'deleteDir()' call which caused an access issue on cleanup