### PR TITLE
Add support for csharp-netcore clients

### DIFF
--- a/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Constants.java
+++ b/dev/org.eclipse.codewind.openapi.ui/src/org/eclipse/codewind/openapi/ui/Constants.java
@@ -50,7 +50,7 @@ public class Constants {
         {"Apex", "apex"},
         {"Bash", "bash"},
         {"C", "c"},
-        {"C#", "csharp", "csharp-dotnet2", "csharp-refactor"},
+        {"C#", "csharp", "csharp-dotnet2", "csharp-refactor", "csharp-netcore"},
         {"C++", "cpp-qt5", "cpp-restsdk", "cpp-tizen"},
         {"Dart", "dart", "dart-jaguar"},
         {"Eiffel", "eiffel"},


### PR DESCRIPTION
Updates the static list of available client SDK generators to include csharp-netcore as per issue [#2481](https://github.com/eclipse/codewind/issues/2481)

Signed-off-by: William Marshall <62070150+BinaryWizard904@users.noreply.github.com>