### PR TITLE
Change the ownership of the test codes after unzip to be able to cleanup workspace 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,9 +73,7 @@ pipeline {
 
                         export CWD=$(pwd)
                         echo "DEBUG: Current directory is ${CWD}"
-                        chmod -R 777 ${CWD}
                     '''
-                    cleanWs()
                 }
             }      
         }  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                             docker build --no-cache -t test-image ./dev
                             export CWD=$(pwd)
                             echo "Current directory is ${CWD}"
-                            docker run --user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
+                            docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
                         '''
                     } finally {
                         junit 'dev/junit-results.xml'
@@ -70,7 +70,12 @@ pipeline {
                         docker builder prune -a -f
                         docker system df
                         df -lh
+
+                        export CWD=$(pwd)
+                        echo "DEBUG: Current directory is ${CWD}"
+                        chmod -R 777 ${CWD}
                     '''
+                    cleanWs()
                 }
             }      
         }  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,10 +70,9 @@ pipeline {
                         docker builder prune -a -f
                         docker system df
                         df -lh
-
-                        export CWD=$(pwd)
-                        echo "DEBUG: Current directory is ${CWD}"
                     '''
+                    echo 'Clean up workspace'	
+                    deleteDir() /* clean up our workspace */
                 }
             }      
         }  

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                             docker build --no-cache -t test-image ./dev
                             export CWD=$(pwd)
                             echo "Current directory is ${CWD}"
-                            docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
+                            docker run --user "$(id -u):$(id -g)" -v /etc/passwd:/etc/passwd:ro -v /var/run/docker.sock:/var/run/docker.sock -v ${CWD}/dev:/development test-image
                         '''
                     } finally {
                         junit 'dev/junit-results.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
             }
         } 
 
-        stage('Test') {
+        stage('Test on docker agent') {
             agent {
                 label "docker-build"
             }

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -12,10 +12,10 @@ echo "Unzipping features..."
 cd /development/ant_build/artifacts/
 
 unzip codewind-openapi-eclipse-0*.zip -d code
-chmod -R 777 code
+chmod -R 755 code
 
 unzip codewind-openapi-eclipse-test*.zip -d test
-chmod -R 777 test
+chmod -R 755 test
 
 cd /home
 

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -12,10 +12,10 @@ echo "Unzipping features..."
 cd /development/ant_build/artifacts/
 
 unzip codewind-openapi-eclipse-0*.zip -d code
-chmod -R 755 code
+chmod -R 777 code
 
 unzip codewind-openapi-eclipse-test*.zip -d test
-chmod -R 755 test
+chmod -R 777 test
 
 cd /home
 

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -12,8 +12,10 @@ echo "Unzipping features..."
 cd /development/ant_build/artifacts/
 
 unzip codewind-openapi-eclipse-0*.zip -d code
+chmod -R 777 code
 
 unzip codewind-openapi-eclipse-test*.zip -d test
+chmod -R 777 test
 
 cd /home
 


### PR DESCRIPTION
This PR will fix https://github.com/eclipse/codewind/issues/2539 for **codewind-openapi-eclipse**